### PR TITLE
Public relay name change

### DIFF
--- a/src/util/app_nostr.ts
+++ b/src/util/app_nostr.ts
@@ -6,6 +6,7 @@ const publicRelays = [
   'wss://nostr.einundzwanzig.space',
   'wss://relay.nostr.info',
   'wss://nostr-relay.untethr.me',
+  'wss://offchain.pub',
   // inactive relays (last checked on 2023-02-01):
   // 'wss://nostr.rocks',
   // 'wss://relay.damus.io',
@@ -15,7 +16,6 @@ const publicRelays = [
   // 'wss://rsslay.fiatjaf.com',
   // 'wss://freedom-relay.herokuapp.com/ws',
   // 'wss://nostr-relay.freeberty.net',
-  // 'wss://nostr.bitcoiner.social',
   // 'wss://nostr.onsats.org',
   // 'wss://nostr.drss.io',
   // 'wss://nostr.unknown.place',


### PR DESCRIPTION
I switched this public relay over to strfry a week ago and it has been rock solid. You can see the uptime and responsiveness on [nostr.watch](https://nostr.watch/relay/offchain.pub). I also changed the domain name:

nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.